### PR TITLE
Replace an obsolete 'Prereq' with the 'Prereqs' plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -3,5 +3,5 @@ copyright_year = 2010
 
 [@MARCEL]
 
-[Prereq]
+[Prereqs]
 Test::HasVersion = 0


### PR DESCRIPTION
...otherwise this hilarity ensues:

```
$ dzil authordeps --missing | xargs -t cpanm
cpanm Dist::Zilla::Plugin::Prereq Dist::Zilla::PluginBundle::MARCEL
--> Working on Dist::Zilla::Plugin::Prereq
Fetching file:///srv/mirrors/CPAN/authors/id/R/RJ/RJBS/Dist-Zilla-5.047.tar.gz ... OK
Configuring Dist-Zilla-5.047 ... OK
Building and testing Dist-Zilla-5.047 ...
```

For very unfunny values of 'hilarity', that is :)
